### PR TITLE
Add GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy-wasm.yml
+++ b/.github/workflows/deploy-wasm.yml
@@ -1,0 +1,37 @@
+name: Deploy WasmJS App to GitHub Pages
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "✅ Checkout code"
+        uses: actions/checkout@v4
+      - name: "⚙️ Set up JDK 21"
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: "⚙️ Setup Gradle"
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+      - name: "🛠️ Build WasmJS App"
+        run: gradle :composeApp:wasmJsBrowserDistribution
+      - name: "📄 Configure GitHub Pages"
+        uses: actions/configure-pages@v5
+      - name: "📤 Upload GitHub Pages artifact"
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./composeApp/build/dist/wasmJs/productionExecutable
+      - name: "🚀 Deploy to GitHub Pages"
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
## Summary
- add a workflow to build the WasmJS app and deploy it to GitHub Pages

## Testing
- `./gradlew :composeApp:wasmJsBrowserDistribution`
- `./gradlew check --stacktrace` *(fails: Lock file was changed. Run the `kotlinWasmUpgradeYarnLock` task to actualize lock file)*

------
https://chatgpt.com/codex/tasks/task_e_688b6dbcbcd8832589811c9c20128943