### PR TITLE
Add status updater script and simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,6 @@
-This is a Kotlin Multiplatform project targeting Web.
+# ComposeMath
 
-* [/composeApp](./composeApp/src) is for code that will be shared across your Compose Multiplatform applications.
-  It contains several subfolders:
-  - [commonMain](./composeApp/src/commonMain/kotlin) is for code that’s common for all targets.
-  - Other folders are for Kotlin code that will be compiled for only the platform indicated in the folder name.
-    For example, if you want to use Apple’s CoreCrypto for the iOS part of your Kotlin app,
-    the [iosMain](./composeApp/src/iosMain/kotlin) folder would be the right place for such calls.
-    Similarly, if you want to edit the Desktop (JVM) specific part, the [jvmMain](./composeApp/src/jvmMain/kotlin)
-    folder is the appropriate location.
+[![Visit GitHub Pages](https://img.shields.io/badge/Visit-ComposeMath-blue?style=for-the-badge)](https://alexander-topilskii.github.io/ComposeMath/)
 
-
-Learn more about [Kotlin Multiplatform](https://www.jetbrains.com/help/kotlin-multiplatform-dev/get-started.html),
-[Compose Multiplatform](https://github.com/JetBrains/compose-multiplatform/#compose-multiplatform),
-[Kotlin/Wasm](https://kotl.in/wasm/)…
-
-We would appreciate your feedback on Compose/Web and Kotlin/Wasm in the public Slack channel [#compose-web](https://slack-chats.kotlinlang.org/c/compose-web).
-If you face any issues, please report them on [YouTrack](https://youtrack.jetbrains.com/newIssue?project=CMP).
-
-You can open the web application by running the `:composeApp:wasmJsBrowserDevelopmentRun` Gradle task.
+**Deployment status:** unknown
+**Last updated:** never

--- a/scripts/update_readme_status.sh
+++ b/scripts/update_readme_status.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Update deployment status and timestamp in README
+# Usage: ./scripts/update_readme_status.sh <status>
+set -euo pipefail
+STATUS="${1:-unknown}"
+TIMESTAMP=$(date -u '+%Y-%m-%d %H:%M UTC')
+# Replace lines in README
+sed -i -E "s#\*\*Deployment status:\*\*.*#**Deployment status:** ${STATUS}#" README.md
+sed -i -E "s#\*\*Last updated:\*\*.*#**Last updated:** ${TIMESTAMP}#" README.md


### PR DESCRIPTION
## Summary
- simplify the README and link to GitHub Pages
- add `update_readme_status.sh` script to update deploy status and time

## Testing
- `./gradlew assemble --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_688c6b4a319083259d5305836478de59