### PR TITLE
feat: support mobile back button

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
@@ -6,44 +6,58 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import kotlinx.browser.window
+import org.example.project.navigation.navigateBack
+import org.example.project.navigation.navigateWithHistory
 import org.example.project.screens.FunctionDrawer
 import org.example.project.screens.calculator.CalculatorScreen
 import org.example.project.screens.details.DetailsScreen
 import org.example.project.screens.examples.ExamplesPage
 import org.example.project.screens.home.HomeScreen
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import org.w3c.dom.events.Event
 
 @Composable
 fun App() {
     MaterialTheme {
-        // Remove column wrapper since HomeScreen now uses Scaffold
-        // and has its own layout handling
-            val navController = rememberNavController()
-            NavHost(navController = navController, startDestination = "home") {
-                composable("home") {
-                    HomeScreen(
-                        onNavigateToDetails = { navController.navigate("details") },
-                        onNavigateToFunction = { navController.navigate("function") },
-                        onNavigateToExamples = { navController.navigate("examples") },
-                        navController = navController
-                    )
-                }
-                composable("details") {
-                    DetailsScreen(onNavigateBack = { navController.popBackStack() })
-                }
-                composable("function") {
-                    FunctionDrawer(modifier = Modifier.fillMaxSize(), onBack = { navController.popBackStack() })
-                }
-                composable("examples") {
-                    ExamplesPage(onBack = { navController.popBackStack() })
-                }
-                composable("calculator") {
-                    CalculatorScreen(onBack = { navController.popBackStack() })
-                }
+        val navController = rememberNavController()
+
+        DisposableEffect(navController) {
+            val handler: (Event) -> Unit = {
+                navController.popBackStack()
             }
+            window.addEventListener("popstate", handler)
+            onDispose {
+                window.removeEventListener("popstate", handler)
+            }
+        }
+
+        NavHost(navController = navController, startDestination = "home") {
+            composable("home") {
+                HomeScreen(
+                    onNavigateToDetails = { navController.navigateWithHistory("details") },
+                    onNavigateToFunction = { navController.navigateWithHistory("function") },
+                    onNavigateToExamples = { navController.navigateWithHistory("examples") },
+                    navController = navController
+                )
+            }
+            composable("details") {
+                DetailsScreen(onNavigateBack = { navigateBack() })
+            }
+            composable("function") {
+                FunctionDrawer(modifier = Modifier.fillMaxSize(), onBack = { navigateBack() })
+            }
+            composable("examples") {
+                ExamplesPage(onBack = { navigateBack() })
+            }
+            composable("calculator") {
+                CalculatorScreen(onBack = { navigateBack() })
+            }
+        }
     }
 }

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/navigation/NavigationUtils.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/navigation/NavigationUtils.kt
@@ -1,0 +1,13 @@
+package org.example.project.navigation
+
+import androidx.navigation.NavController
+import kotlinx.browser.window
+
+fun NavController.navigateWithHistory(route: String) {
+    window.history.pushState(null, "", window.location.href)
+    this.navigate(route)
+}
+
+fun navigateBack() {
+    window.history.back()
+}

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/home/HomeScreen.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.example.project.components.NavCategory
 import org.example.project.components.NavItem
+import org.example.project.navigation.navigateWithHistory
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,7 +79,7 @@ fun HomeScreen(
             title = "Calculator",
             description = "Basic arithmetic calculator",
             categoryId = "tools",
-            onClick = { navController?.navigate("calculator") }
+            onClick = { navController?.navigateWithHistory("calculator") }
         ),
         NavItem(
             id = "settings",


### PR DESCRIPTION
## Summary
- handle browser popstate to sync navigation
- add navigation helpers to push browser history
- use history-aware navigation across screens

## Testing
- `./gradlew build` *(fails: ChromeHeadless missing)*
- `./gradlew assemble`


------
https://chatgpt.com/codex/tasks/task_e_688dddcdcc308325bf89306d35eb71d5