### PR TITLE
Add algorithms navigation and placeholder pages

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
@@ -1,77 +1,88 @@
 package org.example.project
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import kotlinx.browser.window
+import org.example.project.navigation.navigateBack
+import org.example.project.navigation.navigateWithHistory
 import org.example.project.screens.FunctionDrawer
 import org.example.project.screens.calculator.CalculatorScreen
 import org.example.project.screens.details.DetailsScreen
 import org.example.project.screens.examples.ExamplesPage
 import org.example.project.screens.home.HomeScreen
 import org.example.project.screens.algorithms.*
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.rememberNavController
+import org.w3c.dom.events.Event
 
 @Composable
 fun App() {
     MaterialTheme {
-        // Remove column wrapper since HomeScreen now uses Scaffold
-        // and has its own layout handling
-            val navController = rememberNavController()
-            NavHost(navController = navController, startDestination = "home") {
-                composable("home") {
-                    HomeScreen(
-                        onNavigateToDetails = { navController.navigate("details") },
-                        onNavigateToFunction = { navController.navigate("function") },
-                        onNavigateToExamples = { navController.navigate("examples") },
-                        navController = navController
-                    )
-                }
-                composable("algorithms") {
-                    AlgorithmsPage(
-                        onBack = { navController.popBackStack() },
-                        onNavigate = { route -> navController.navigate(route) }
-                    )
-                }
-                composable("quick_merge_sort") {
-                    QuickMergeSortScreen(onBack = { navController.popBackStack() })
-                }
-                composable("insertion_bubble_sort") {
-                    InsertionBubbleSortScreen(onBack = { navController.popBackStack() })
-                }
-                composable("binary_linear_search") {
-                    BinaryLinearSearchScreen(onBack = { navController.popBackStack() })
-                }
-                composable("bfs_dfs") {
-                    BfsDfsScreen(onBack = { navController.popBackStack() })
-                }
-                composable("dijkstra_bellman_ford") {
-                    DijkstraBellmanFordScreen(onBack = { navController.popBackStack() })
-                }
-                composable("bridges_components") {
-                    BridgesComponentsScreen(onBack = { navController.popBackStack() })
-                }
-                composable("floyd_warshall_prim") {
-                    FloydWarshallPrimScreen(onBack = { navController.popBackStack() })
-                }
-                composable("details") {
-                    DetailsScreen(onNavigateBack = { navController.popBackStack() })
-                }
-                composable("function") {
-                    FunctionDrawer(modifier = Modifier.fillMaxSize(), onBack = { navController.popBackStack() })
-                }
-                composable("examples") {
-                    ExamplesPage(onBack = { navController.popBackStack() })
-                }
-                composable("calculator") {
-                    CalculatorScreen(onBack = { navController.popBackStack() })
-                }
+        val navController = rememberNavController()
+
+        DisposableEffect(navController) {
+            val handler: (Event) -> Unit = {
+                navController.popBackStack()
             }
+            window.addEventListener("popstate", handler)
+            onDispose {
+                window.removeEventListener("popstate", handler)
+            }
+        }
+
+        NavHost(navController = navController, startDestination = "home") {
+            composable("home") {
+                HomeScreen(
+                    onNavigateToDetails = { navController.navigateWithHistory("details") },
+                    onNavigateToFunction = { navController.navigateWithHistory("function") },
+                    onNavigateToExamples = { navController.navigateWithHistory("examples") },
+                    navController = navController
+                )
+            }
+            composable("algorithms") {
+                AlgorithmsPage(
+                    onBack = { navigateBack() },
+                    onNavigate = { route -> navController.navigateWithHistory(route) }
+                )
+            }
+            composable("quick_merge_sort") {
+                QuickMergeSortScreen(onBack = { navigateBack() })
+            }
+            composable("insertion_bubble_sort") {
+                InsertionBubbleSortScreen(onBack = { navigateBack() })
+            }
+            composable("binary_linear_search") {
+                BinaryLinearSearchScreen(onBack = { navigateBack() })
+            }
+            composable("bfs_dfs") {
+                BfsDfsScreen(onBack = { navigateBack() })
+            }
+            composable("dijkstra_bellman_ford") {
+                DijkstraBellmanFordScreen(onBack = { navigateBack() })
+            }
+            composable("bridges_components") {
+                BridgesComponentsScreen(onBack = { navigateBack() })
+            }
+            composable("floyd_warshall_prim") {
+                FloydWarshallPrimScreen(onBack = { navigateBack() })
+            }
+            composable("details") {
+                DetailsScreen(onNavigateBack = { navigateBack() })
+            }
+            composable("function") {
+                FunctionDrawer(modifier = Modifier.fillMaxSize(), onBack = { navigateBack() })
+            }
+            composable("examples") {
+                ExamplesPage(onBack = { navigateBack() })
+            }
+            composable("calculator") {
+                CalculatorScreen(onBack = { navigateBack() })
+            }
+        }
     }
 }
+

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
@@ -13,6 +13,7 @@ import org.example.project.screens.calculator.CalculatorScreen
 import org.example.project.screens.details.DetailsScreen
 import org.example.project.screens.examples.ExamplesPage
 import org.example.project.screens.home.HomeScreen
+import org.example.project.screens.algorithms.*
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -31,6 +32,33 @@ fun App() {
                         onNavigateToExamples = { navController.navigate("examples") },
                         navController = navController
                     )
+                }
+                composable("algorithms") {
+                    AlgorithmsPage(
+                        onBack = { navController.popBackStack() },
+                        onNavigate = { route -> navController.navigate(route) }
+                    )
+                }
+                composable("quick_merge_sort") {
+                    QuickMergeSortScreen(onBack = { navController.popBackStack() })
+                }
+                composable("insertion_bubble_sort") {
+                    InsertionBubbleSortScreen(onBack = { navController.popBackStack() })
+                }
+                composable("binary_linear_search") {
+                    BinaryLinearSearchScreen(onBack = { navController.popBackStack() })
+                }
+                composable("bfs_dfs") {
+                    BfsDfsScreen(onBack = { navController.popBackStack() })
+                }
+                composable("dijkstra_bellman_ford") {
+                    DijkstraBellmanFordScreen(onBack = { navController.popBackStack() })
+                }
+                composable("bridges_components") {
+                    BridgesComponentsScreen(onBack = { navController.popBackStack() })
+                }
+                composable("floyd_warshall_prim") {
+                    FloydWarshallPrimScreen(onBack = { navController.popBackStack() })
                 }
                 composable("details") {
                     DetailsScreen(onNavigateBack = { navController.popBackStack() })

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/navigation/NavigationUtils.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/navigation/NavigationUtils.kt
@@ -1,0 +1,13 @@
+package org.example.project.navigation
+
+import androidx.navigation.NavController
+import kotlinx.browser.window
+
+fun NavController.navigateWithHistory(route: String) {
+    window.history.pushState(null, "", window.location.href)
+    this.navigate(route)
+}
+
+fun navigateBack() {
+    window.history.back()
+}

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/algorithms/AlgorithmScreens.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/algorithms/AlgorithmScreens.kt
@@ -1,0 +1,67 @@
+package org.example.project.screens.algorithms
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun QuickMergeSortScreen(onBack: () -> Unit) {
+    AlgorithmPlaceholderScreen("Быстрая сортировка, сортировка слиянием", onBack)
+}
+
+@Composable
+fun InsertionBubbleSortScreen(onBack: () -> Unit) {
+    AlgorithmPlaceholderScreen("Сортировка вставками, пузырьком", onBack)
+}
+
+@Composable
+fun BinaryLinearSearchScreen(onBack: () -> Unit) {
+    AlgorithmPlaceholderScreen("Бинарный поиск, линейный поиск", onBack)
+}
+
+@Composable
+fun BfsDfsScreen(onBack: () -> Unit) {
+    AlgorithmPlaceholderScreen("Поиск в ширину (BFS), в глубину (DFS)", onBack)
+}
+
+@Composable
+fun DijkstraBellmanFordScreen(onBack: () -> Unit) {
+    AlgorithmPlaceholderScreen("Алгоритм Дейкстры, Беллмана-Форда", onBack)
+}
+
+@Composable
+fun BridgesComponentsScreen(onBack: () -> Unit) {
+    AlgorithmPlaceholderScreen("Поиск мостов, компонент связности", onBack)
+}
+
+@Composable
+fun FloydWarshallPrimScreen(onBack: () -> Unit) {
+    AlgorithmPlaceholderScreen("Алгоритм Флойда-Уоршелла, Прима", onBack)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AlgorithmPlaceholderScreen(title: String, onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) { Text("←") }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("Страница в разработке")
+        }
+    }
+}
+

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/algorithms/AlgorithmsPage.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/algorithms/AlgorithmsPage.kt
@@ -1,0 +1,77 @@
+package org.example.project.screens.algorithms
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import org.example.project.components.NavCategory
+import org.example.project.components.NavItem
+import org.example.project.components.NavigationTemplate
+
+@Composable
+fun AlgorithmsPage(onBack: () -> Unit, onNavigate: (String) -> Unit) {
+    val categories = listOf(
+        NavCategory("search_sort", "Алгоритмы поиска и сортировки", Color(0xFF42A5F5)),
+        NavCategory("graph", "Графовые алгоритмы", Color(0xFF66BB6A))
+    )
+
+    val navItems = listOf(
+        NavItem(
+            id = "quick_merge_sort",
+            title = "Быстрая сортировка, сортировка слиянием",
+            description = "",
+            categoryId = "search_sort",
+            onClick = { onNavigate("quick_merge_sort") }
+        ),
+        NavItem(
+            id = "insertion_bubble_sort",
+            title = "Сортировка вставками, пузырьком",
+            description = "",
+            categoryId = "search_sort",
+            onClick = { onNavigate("insertion_bubble_sort") }
+        ),
+        NavItem(
+            id = "binary_linear_search",
+            title = "Бинарный поиск, линейный поиск",
+            description = "",
+            categoryId = "search_sort",
+            onClick = { onNavigate("binary_linear_search") }
+        ),
+        NavItem(
+            id = "bfs_dfs",
+            title = "Поиск в ширину (BFS), в глубину (DFS)",
+            description = "",
+            categoryId = "graph",
+            onClick = { onNavigate("bfs_dfs") }
+        ),
+        NavItem(
+            id = "dijkstra_bellman_ford",
+            title = "Алгоритм Дейкстры, Беллмана-Форда",
+            description = "",
+            categoryId = "graph",
+            onClick = { onNavigate("dijkstra_bellman_ford") }
+        ),
+        NavItem(
+            id = "bridges_components",
+            title = "Поиск мостов, компонент связности",
+            description = "",
+            categoryId = "graph",
+            onClick = { onNavigate("bridges_components") }
+        ),
+        NavItem(
+            id = "floyd_warshall_prim",
+            title = "Алгоритм Флойда-Уоршелла, Прима",
+            description = "",
+            categoryId = "graph",
+            onClick = { onNavigate("floyd_warshall_prim") }
+        )
+    )
+
+    NavigationTemplate(
+        title = "Алгоритмы",
+        categories = categories,
+        items = navItems,
+        onBack = onBack,
+        modifier = Modifier
+    )
+}
+

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/home/HomeScreen.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.example.project.components.NavCategory
 import org.example.project.components.NavItem
+import org.example.project.navigation.navigateWithHistory
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,7 +80,7 @@ fun HomeScreen(
             title = "Calculator",
             description = "Basic arithmetic calculator",
             categoryId = "tools",
-            onClick = { navController?.navigate("calculator") }
+            onClick = { navController?.navigateWithHistory("calculator") }
         ),
         NavItem(
             id = "settings",
@@ -100,7 +101,7 @@ fun HomeScreen(
             title = "Алгоритмы",
             description = "Навигация по алгоритмам",
             categoryId = "algorithms",
-            onClick = { navController?.navigate("algorithms") }
+            onClick = { navController?.navigateWithHistory("algorithms") }
         ),
         NavItem(
             id = "about",

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/home/HomeScreen.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/home/HomeScreen.kt
@@ -35,7 +35,8 @@ fun HomeScreen(
     val categories = listOf(
         NavCategory("demos", "Demo Pages", Color(0xFF5B8EDB)),
         NavCategory("tools", "Interactive Tools", Color(0xFF26A69A)),
-        NavCategory("examples", "Examples", Color(0xFFEF6C00))
+        NavCategory("examples", "Examples", Color(0xFFEF6C00)),
+        NavCategory("algorithms", "Алгоритмы", Color(0xFF9C27B0))
     )
 
     // Function to derive a shade from category color
@@ -93,6 +94,13 @@ fun HomeScreen(
             description = "Browse various code examples",
             categoryId = "examples",
             onClick = onNavigateToExamples
+        ),
+        NavItem(
+            id = "algorithms",
+            title = "Алгоритмы",
+            description = "Навигация по алгоритмам",
+            categoryId = "algorithms",
+            onClick = { navController?.navigate("algorithms") }
         ),
         NavItem(
             id = "about",


### PR DESCRIPTION
## Summary
- add new "Алгоритмы" category to home navigation
- introduce AlgorithmsPage with search/sort and graph algorithm sections
- create placeholder subpages for algorithm topics and register routes

## Testing
- `./gradlew build` *(fails: Lock file was changed. Run the `kotlinWasmUpgradeYarnLock` task to actualize lock file)*

------
https://chatgpt.com/codex/tasks/task_e_688ddeb26b348325b3ee4f2060f6ed1e