### PR TITLE
Add algorithms navigation and placeholder pages

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
@@ -16,6 +16,7 @@ import kotlinx.browser.window
 import org.example.project.navigation.navigateBack
 import org.example.project.navigation.navigateWithHistory
 import org.example.project.screens.FunctionDrawer
+import org.example.project.screens.algorithms.*
 import org.example.project.screens.calculator.CalculatorScreen
 import org.example.project.screens.details.DetailsScreen
 import org.example.project.screens.examples.ExamplesPage
@@ -54,6 +55,30 @@ fun App() {
             }
             composable("examples") {
                 ExamplesPage(onBack = { navigateBack() })
+            }
+            composable("algorithms") {
+                AlgorithmsPage(onBack = { navigateBack() }, navController = navController)
+            }
+            composable("quick_merge") {
+                QuickMergeSortScreen(onBack = { navigateBack() })
+            }
+            composable("insert_bubble") {
+                InsertBubbleSortScreen(onBack = { navigateBack() })
+            }
+            composable("binary_linear") {
+                BinaryLinearSearchScreen(onBack = { navigateBack() })
+            }
+            composable("bfs_dfs") {
+                BfsDfsScreen(onBack = { navigateBack() })
+            }
+            composable("dijkstra_bellman_ford") {
+                DijkstraBellmanFordScreen(onBack = { navigateBack() })
+            }
+            composable("bridges_components") {
+                BridgesComponentsScreen(onBack = { navigateBack() })
+            }
+            composable("floyd_warshall_prim") {
+                FloydWarshallPrimScreen(onBack = { navigateBack() })
             }
             composable("calculator") {
                 CalculatorScreen(onBack = { navigateBack() })

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/algorithms/AlgorithmsPage.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/algorithms/AlgorithmsPage.kt
@@ -1,0 +1,128 @@
+package org.example.project.screens.algorithms
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.navigation.NavController
+import org.example.project.components.NavCategory
+import org.example.project.components.NavItem
+import org.example.project.components.NavigationTemplate
+import org.example.project.navigation.navigateWithHistory
+
+@Composable
+fun AlgorithmsPage(onBack: () -> Unit, navController: NavController) {
+    val categories = listOf(
+        NavCategory("search_sort", "Алгоритмы поиска и сортировки", Color(0xFFEC407A)),
+        NavCategory("graph", "Графовые алгоритмы", Color(0xFF7E57C2))
+    )
+
+    val navItems = listOf(
+        NavItem(
+            id = "quick_merge",
+            title = "Быстрая сортировка, слиянием",
+            description = "",
+            categoryId = "search_sort",
+            onClick = { navController.navigateWithHistory("quick_merge") }
+        ),
+        NavItem(
+            id = "insert_bubble",
+            title = "Сортировка вставками, пузырьком",
+            description = "",
+            categoryId = "search_sort",
+            onClick = { navController.navigateWithHistory("insert_bubble") }
+        ),
+        NavItem(
+            id = "binary_linear",
+            title = "Бинарный поиск, линейный поиск",
+            description = "",
+            categoryId = "search_sort",
+            onClick = { navController.navigateWithHistory("binary_linear") }
+        ),
+        NavItem(
+            id = "bfs_dfs",
+            title = "Поиск в ширину (BFS), в глубину (DFS)",
+            description = "",
+            categoryId = "graph",
+            onClick = { navController.navigateWithHistory("bfs_dfs") }
+        ),
+        NavItem(
+            id = "dijkstra_bellman_ford",
+            title = "Алгоритм Дейкстры, Беллмана-Форда",
+            description = "",
+            categoryId = "graph",
+            onClick = { navController.navigateWithHistory("dijkstra_bellman_ford") }
+        ),
+        NavItem(
+            id = "bridges_components",
+            title = "Поиск мостов, компонент связности",
+            description = "",
+            categoryId = "graph",
+            onClick = { navController.navigateWithHistory("bridges_components") }
+        ),
+        NavItem(
+            id = "floyd_warshall_prim",
+            title = "Алгоритм Флойда-Уоршелла, Прима",
+            description = "",
+            categoryId = "graph",
+            onClick = { navController.navigateWithHistory("floyd_warshall_prim") }
+        )
+    )
+
+    NavigationTemplate(
+        title = "Алгоритмы",
+        categories = categories,
+        items = navItems,
+        onBack = onBack
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlgorithmPlaceholderScreen(title: String, onBack: () -> Unit) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) { Text("←") }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentAlignment = Alignment.Center
+        ) {
+            Text("Содержимое появится позже")
+        }
+    }
+}
+
+@Composable
+fun QuickMergeSortScreen(onBack: () -> Unit) = AlgorithmPlaceholderScreen("Быстрая сортировка, слиянием", onBack)
+
+@Composable
+fun InsertBubbleSortScreen(onBack: () -> Unit) = AlgorithmPlaceholderScreen("Сортировка вставками, пузырьком", onBack)
+
+@Composable
+fun BinaryLinearSearchScreen(onBack: () -> Unit) = AlgorithmPlaceholderScreen("Бинарный поиск, линейный поиск", onBack)
+
+@Composable
+fun BfsDfsScreen(onBack: () -> Unit) = AlgorithmPlaceholderScreen("Поиск в ширину (BFS), в глубину (DFS)", onBack)
+
+@Composable
+fun DijkstraBellmanFordScreen(onBack: () -> Unit) = AlgorithmPlaceholderScreen("Алгоритм Дейкстры, Беллмана-Форда", onBack)
+
+@Composable
+fun BridgesComponentsScreen(onBack: () -> Unit) = AlgorithmPlaceholderScreen("Поиск мостов, компонент связности", onBack)
+
+@Composable
+fun FloydWarshallPrimScreen(onBack: () -> Unit) = AlgorithmPlaceholderScreen("Алгоритм Флойда-Уоршелла, Прима", onBack)
+

--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/home/HomeScreen.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/screens/home/HomeScreen.kt
@@ -36,7 +36,8 @@ fun HomeScreen(
     val categories = listOf(
         NavCategory("demos", "Demo Pages", Color(0xFF5B8EDB)),
         NavCategory("tools", "Interactive Tools", Color(0xFF26A69A)),
-        NavCategory("examples", "Examples", Color(0xFFEF6C00))
+        NavCategory("examples", "Examples", Color(0xFFEF6C00)),
+        NavCategory("algorithms", "Алгоритмы", Color(0xFF42A5F5))
     )
 
     // Function to derive a shade from category color
@@ -101,6 +102,13 @@ fun HomeScreen(
             description = "Information about this application",
             categoryId = "examples",
             onClick = { /* TODO */ }
+        ),
+        NavItem(
+            id = "algorithms",
+            title = "Алгоритмы",
+            description = "Навигация по алгоритмам",
+            categoryId = "algorithms",
+            onClick = { navController?.navigateWithHistory("algorithms") }
         )
     )
 

--- a/kotlin-js-store/wasm/yarn.lock
+++ b/kotlin-js-store/wasm/yarn.lock
@@ -865,9 +865,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.5.173:
-  version "1.5.193"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.193.tgz#35b1f9a134023d68a7632616457e0fc282f37101"
-  integrity sha512-eePuBZXM9OVCwfYUhd2OzESeNGnWmLyeu0XAEjf7xjijNjHFdeJSzuRUGN4ueT2tEYo5YqjHramKEFxz67p3XA==
+  version "1.5.194"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.194.tgz#05e541c3373ba8d967a65c92bc14d60608908236"
+  integrity sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -1148,9 +1148,9 @@ flatted@^3.2.7:
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 follow-redirects@^1.0.0:
-  version "1.15.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.10.tgz#1e23a287c79cf794cea91e5c81075bfdd75da07c"
-  integrity sha512-V7O/fFKM539IC2bweloFWuoiJ9OtI3W2uIqJPWM8IT5xxNyt73QtvVqmSpcDmk07ivmmlKB+rRY0vpQjIYNtKw==
+  version "1.15.11"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 format-util@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Summary
- add algorithms section and navigation on the home page
- provide algorithms navigation page with search/sort and graph categories
- stub out empty algorithm detail screens

## Testing
- `./gradlew build` *(fails: Errors occurred during launch of browser for testing. Please make sure that you have installed browsers.)*

------
https://chatgpt.com/codex/tasks/task_e_688deb7d44448325885de864ec36c608