### PR TITLE
Enable text selection across site

### DIFF
--- a/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
+++ b/composeApp/src/wasmJsMain/kotlin/org/example/project/App.kt
@@ -1,13 +1,10 @@
 package org.example.project
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeContentPadding
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -26,19 +23,20 @@ import org.w3c.dom.events.Event
 @Composable
 fun App() {
     MaterialTheme {
-        val navController = rememberNavController()
+        SelectionContainer {
+            val navController = rememberNavController()
 
-        DisposableEffect(navController) {
-            val handler: (Event) -> Unit = {
-                navController.popBackStack()
+            DisposableEffect(navController) {
+                val handler: (Event) -> Unit = {
+                    navController.popBackStack()
+                }
+                window.addEventListener("popstate", handler)
+                onDispose {
+                    window.removeEventListener("popstate", handler)
+                }
             }
-            window.addEventListener("popstate", handler)
-            onDispose {
-                window.removeEventListener("popstate", handler)
-            }
-        }
 
-        NavHost(navController = navController, startDestination = "home") {
+            NavHost(navController = navController, startDestination = "home") {
             composable("home") {
                 HomeScreen(
                     onNavigateToDetails = { navController.navigateWithHistory("details") },
@@ -82,6 +80,7 @@ fun App() {
             }
             composable("calculator") {
                 CalculatorScreen(onBack = { navigateBack() })
+            }
             }
         }
     }

--- a/composeApp/src/wasmJsMain/resources/styles.css
+++ b/composeApp/src/wasmJsMain/resources/styles.css
@@ -5,3 +5,10 @@ html, body {
     padding: 0;
     overflow: hidden;
 }
+
+* {
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
+}


### PR DESCRIPTION
## Summary
- allow selecting any text by adding global CSS `user-select` rules
- wrap app content in `SelectionContainer` so titles and text can be copied

## Testing
- `./gradlew test` *(fails: Task 'test' not found)*
- `./gradlew build` *(fails: ChromeHeadless not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688df6ce59b88325913eb31c81d3250c