### PR TITLE
Enable text selection across site

### DIFF
--- a/composeApp/src/wasmJsMain/resources/styles.css
+++ b/composeApp/src/wasmJsMain/resources/styles.css
@@ -7,8 +7,8 @@ html, body {
 }
 
 * {
-    -webkit-user-select: text;
-    -moz-user-select: text;
-    -ms-user-select: text;
-    user-select: text;
+    -webkit-user-select: text !important;
+    -moz-user-select: text !important;
+    -ms-user-select: text !important;
+    user-select: text !important;
 }


### PR DESCRIPTION
## Summary
- Force-enable text selection globally with CSS so text can be copied

## Testing
- `./gradlew test` *(fails: Task 'test' not found)*
- `./gradlew wasmJsTest` *(fails: Errors occurred during launch of browser for testing: ChromeHeadless not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896fbb458808325bfde2c098ee9f3a0